### PR TITLE
Fixed Bug - Play2.1 passes invalid 'rjs' option to TypescriptCompiler.

### DIFF
--- a/src/main/scala/TypeScriptCompiler.scala
+++ b/src/main/scala/TypeScriptCompiler.scala
@@ -23,7 +23,7 @@ object TypeScriptCompiler {
       val tempOut = createTempDir()
       val outOption = Seq("--out", tempOut.getPath)
       val tscOutput = runCompiler(
-        cmd ++ options ++ writeDeclarationsOptions ++ outOption ++ Seq(tsFile.getAbsolutePath)
+        cmd ++ options.filter( _ != "rjs" ) ++ writeDeclarationsOptions ++ outOption ++ Seq(tsFile.getAbsolutePath)
       )
 
       val tsOutput = Path.fromString(tempOut + File.separator + tsFile.getName.replaceAll("\\.ts$", ".js")).string


### PR DESCRIPTION
Play2.1 passes the option 'rjs' to TypescriptCompiler. Here's a patch to filter it out to avoid CLI errors.

This occurs only when the "requireJs" option is specified in your projects build config, and only during debug mode (`play run`) - otherwise it works correctly.

i.e.
val main = play.Project(appName, appVersion, appDependencies).settings(
    requireJs := Seq( "main.js" )
)
