### PR TITLE
avoid overriding settings 

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object PluginBuild extends Build {
     resolvers += Resolver.url("Typesafe ivy releases", url("http://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns),
     addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0" % "provided"),
     organization := "com.github.mumoshu",
-    version := "0.2-RC10",
+    version := "0.2-RC11",
     publishMavenStyle := true,
     publishArtifact in Test := false,
     pomIncludeRepository := { _ => false },

--- a/src/main/scala/TypeScriptPlugin.scala
+++ b/src/main/scala/TypeScriptPlugin.scala
@@ -4,7 +4,7 @@ import sbt._
 import sbt.Keys._
 
 object TypeScriptPlugin extends Plugin with TypeScriptSettings {
-    override val settings = defaultSettings
+    val typescript = defaultSettings
 }
 
 // vim: set ts=4 sw=4 et:


### PR DESCRIPTION
since a build can contain multiple projects and you dont want to import the plugin for all of them
